### PR TITLE
[change]管理者ユーザーのパスワードに変更を掛けました

### DIFF
--- a/ddl.sql
+++ b/ddl.sql
@@ -13,7 +13,7 @@ CREATE TABLE users (
   admin_flag boolean DEFAULT false
 );
 -- 管理者のアカウントのみ最初からいれる
-INSERT INTO users VALUES(null, "admin", "sample@jp.com", "2ba1a731ccf5fd0865fa58e9dd335b4f409734d41f31a638f9f28cbbd7acaf80", "qwertyuisdfg", false, true);
+INSERT INTO users VALUES(null, "admin", "sample@jp.com", "339ff53caac9a14a40f2e7cb7de73a00e6535a9caede80bd929bd6dc077c8506", "qwertyuisdfg", false, true);
 
 -- 追加機能用に閲覧数・ベストアンサーをつけておく
 create table question(


### PR DESCRIPTION
管理者ユーザーの前パスワードを忘れたので、新しくパスワードを設定しハッシュ化した値を代入しました。

前のdbのまま使用したい場合は、下記のコマンドを実行してください
update users set student_pass = "339ff53caac9a14a40f2e7cb7de73a00e6535a9caede80bd929bd6dc077c8506" where user_id=1;

開発中に管理者アカウントにログインする際は、下の通りでお願いします
mailaddress : sample@jp.com
password : morijyobi2021